### PR TITLE
feat: Add completion and resource template support

### DIFF
--- a/src/core/MCPServer.ts
+++ b/src/core/MCPServer.ts
@@ -9,6 +9,8 @@ import {
   ReadResourceRequestSchema,
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
+  CompleteRequestSchema,
+  ListResourceTemplatesRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { ToolProtocol } from "../tools/BaseTool.js";
 import { PromptProtocol } from "../prompts/BasePrompt.js";
@@ -59,7 +61,7 @@ export class MCPServer {
     this.serverVersion = config.version ?? this.getDefaultVersion();
 
     logger.info(
-      `Initializing MCP Server: ${this.serverName}@${this.serverVersion}`
+      `Initializing MCP Server: ${this.serverName}@${this.serverVersion}`,
     );
 
     this.toolLoader = new ToolLoader(this.basePath);
@@ -77,7 +79,7 @@ export class MCPServer {
           prompts: { enabled: false },
           resources: { enabled: false },
         },
-      }
+      },
     );
 
     this.setupHandlers();
@@ -128,7 +130,7 @@ export class MCPServer {
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: Array.from(this.toolsMap.values()).map(
-          (tool) => tool.toolDefinition
+          (tool) => tool.toolDefinition,
         ),
       };
     });
@@ -138,8 +140,8 @@ export class MCPServer {
       if (!tool) {
         throw new Error(
           `Unknown tool: ${request.params.name}. Available tools: ${Array.from(
-            this.toolsMap.keys()
-          ).join(", ")}`
+            this.toolsMap.keys(),
+          ).join(", ")}`,
         );
       }
 
@@ -154,7 +156,7 @@ export class MCPServer {
     this.server.setRequestHandler(ListPromptsRequestSchema, async () => {
       return {
         prompts: Array.from(this.promptsMap.values()).map(
-          (prompt) => prompt.promptDefinition
+          (prompt) => prompt.promptDefinition,
         ),
       };
     });
@@ -166,8 +168,8 @@ export class MCPServer {
           `Unknown prompt: ${
             request.params.name
           }. Available prompts: ${Array.from(this.promptsMap.keys()).join(
-            ", "
-          )}`
+            ", ",
+          )}`,
         );
       }
 
@@ -179,10 +181,23 @@ export class MCPServer {
     this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
       return {
         resources: Array.from(this.resourcesMap.values()).map(
-          (resource) => resource.resourceDefinition
+          (resource) => resource.resourceDefinition,
         ),
       };
     });
+
+    this.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async () => {
+        const templates = Array.from(this.resourcesMap.values())
+          .map((resource) => resource.templateDefinition)
+          .filter((template): template is NonNullable<typeof template> =>
+            Boolean(template),
+          );
+
+        return { resourceTemplates: templates };
+      },
+    );
 
     this.server.setRequestHandler(
       ReadResourceRequestSchema,
@@ -193,15 +208,15 @@ export class MCPServer {
             `Unknown resource: ${
               request.params.uri
             }. Available resources: ${Array.from(this.resourcesMap.keys()).join(
-              ", "
-            )}`
+              ", ",
+            )}`,
           );
         }
 
         return {
           contents: await resource.read(),
         };
-      }
+      },
     );
 
     this.server.setRequestHandler(SubscribeRequestSchema, async (request) => {
@@ -212,7 +227,7 @@ export class MCPServer {
 
       if (!resource.subscribe) {
         throw new Error(
-          `Resource ${request.params.uri} does not support subscriptions`
+          `Resource ${request.params.uri} does not support subscriptions`,
         );
       }
 
@@ -228,12 +243,38 @@ export class MCPServer {
 
       if (!resource.unsubscribe) {
         throw new Error(
-          `Resource ${request.params.uri} does not support subscriptions`
+          `Resource ${request.params.uri} does not support subscriptions`,
         );
       }
 
       await resource.unsubscribe();
       return {};
+    });
+
+    this.server.setRequestHandler(CompleteRequestSchema, async (request) => {
+      const { ref, argument } = request.params;
+
+      if (ref.type === "ref/prompt") {
+        const prompt = this.promptsMap.get(ref.name);
+        if (!prompt?.complete) {
+          return { completion: { values: [] } };
+        }
+        return {
+          completion: await prompt.complete(argument.name, argument.value),
+        };
+      }
+
+      if (ref.type === "ref/resource") {
+        const resource = this.resourcesMap.get(ref.uri);
+        if (!resource?.complete) {
+          return { completion: { values: [] } };
+        }
+        return {
+          completion: await resource.complete(argument.name, argument.value),
+        };
+      }
+
+      throw new Error(`Unknown reference type: ${ref}`);
     });
   }
 
@@ -262,17 +303,17 @@ export class MCPServer {
     try {
       const tools = await this.toolLoader.loadTools();
       this.toolsMap = new Map(
-        tools.map((tool: ToolProtocol) => [tool.name, tool])
+        tools.map((tool: ToolProtocol) => [tool.name, tool]),
       );
 
       const prompts = await this.promptLoader.loadPrompts();
       this.promptsMap = new Map(
-        prompts.map((prompt: PromptProtocol) => [prompt.name, prompt])
+        prompts.map((prompt: PromptProtocol) => [prompt.name, prompt]),
       );
 
       const resources = await this.resourceLoader.loadResources();
       this.resourcesMap = new Map(
-        resources.map((resource: ResourceProtocol) => [resource.uri, resource])
+        resources.map((resource: ResourceProtocol) => [resource.uri, resource]),
       );
 
       await this.detectCapabilities();
@@ -285,22 +326,22 @@ export class MCPServer {
       if (tools.length > 0) {
         logger.info(
           `Tools (${tools.length}): ${Array.from(this.toolsMap.keys()).join(
-            ", "
-          )}`
+            ", ",
+          )}`,
         );
       }
       if (prompts.length > 0) {
         logger.info(
           `Prompts (${prompts.length}): ${Array.from(
-            this.promptsMap.keys()
-          ).join(", ")}`
+            this.promptsMap.keys(),
+          ).join(", ")}`,
         );
       }
       if (resources.length > 0) {
         logger.info(
           `Resources (${resources.length}): ${Array.from(
-            this.resourcesMap.keys()
-          ).join(", ")}`
+            this.resourcesMap.keys(),
+          ).join(", ")}`,
         );
       }
     } catch (error) {

--- a/src/resources/BaseResource.ts
+++ b/src/resources/BaseResource.ts
@@ -19,15 +19,23 @@ export type ResourceTemplateDefinition = {
   mimeType?: string;
 };
 
+export type ResourceCompletion = {
+  values: string[];
+  total?: number;
+  hasMore?: boolean;
+};
+
 export interface ResourceProtocol {
   uri: string;
   name: string;
   description?: string;
   mimeType?: string;
   resourceDefinition: ResourceDefinition;
+  templateDefinition?: ResourceTemplateDefinition;
   read(): Promise<ResourceContent[]>;
   subscribe?(): Promise<void>;
   unsubscribe?(): Promise<void>;
+  complete?(argument: string, name: string): Promise<ResourceCompletion>;
 }
 
 export abstract class MCPResource implements ResourceProtocol {
@@ -35,12 +43,29 @@ export abstract class MCPResource implements ResourceProtocol {
   abstract name: string;
   description?: string;
   mimeType?: string;
+  protected template?: {
+    uriTemplate: string;
+    description?: string;
+  };
 
   get resourceDefinition(): ResourceDefinition {
     return {
       uri: this.uri,
       name: this.name,
       description: this.description,
+      mimeType: this.mimeType,
+    };
+  }
+
+  get templateDefinition(): ResourceTemplateDefinition | undefined {
+    if (!this.template) {
+      return undefined;
+    }
+
+    return {
+      uriTemplate: this.template.uriTemplate,
+      name: this.name,
+      description: this.template.description ?? this.description,
       mimeType: this.mimeType,
     };
   }
@@ -53,6 +78,17 @@ export abstract class MCPResource implements ResourceProtocol {
 
   async unsubscribe?(): Promise<void> {
     throw new Error("Unsubscription not implemented for this resource");
+  }
+
+  async complete?(
+    argument: string,
+    value: string,
+  ): Promise<ResourceCompletion> {
+    return {
+      values: [],
+      total: 0,
+      hasMore: false,
+    };
   }
 
   protected async fetch<T>(url: string, init?: RequestInit): Promise<T> {


### PR DESCRIPTION
- Add support for MCP completions
- Implement URI templates for dynamic resources
- Add completion handlers for prompts and resources
- Update documentation with new features and examples

This implementation follows the MCP specification for completions and resource templates while maintaining backwards compatibility.

References:
https://spec.modelcontextprotocol.io/specification/server/resources/#resource-templates
https://spec.modelcontextprotocol.io/specification/server/utilities/completion/