### PR TITLE
fix: Prevent duplicate builds by removing prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch",
-    "prepare": "npm run build"
+    "watch": "tsc --watch"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/cli/project/create.ts
+++ b/src/cli/project/create.ts
@@ -56,7 +56,6 @@ export async function createProject(name?: string) {
       files: ["dist"],
       scripts: {
         build: "tsc && mcp-build",
-        prepare: "npm run build",
         watch: "tsc --watch",
         start: "node dist/index.js"
       },


### PR DESCRIPTION
This PR removes the "prepare": "npm run build" script from both the root package.json and the generated package.json in create.ts. These changes prevent the build process from running twice during project creation, ensuring a single, efficient build step.