### PR TITLE
fix: enforce maxMessageSize in readRequestBody

### DIFF
--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -222,9 +222,17 @@ export class HttpStreamTransport extends AbstractTransport {
   }
 
   private async readRequestBody(req: IncomingMessage): Promise<any> {
+    const maxSize = this._config.maxMessageSize ?? 4 * 1024 * 1024;
     return new Promise((resolve, reject) => {
       let body = '';
+      let size = 0;
       req.on('data', (chunk) => {
+        size += chunk.length;
+        if (size > maxSize) {
+          req.destroy();
+          reject(new Error(`Request body exceeds maximum size of ${maxSize} bytes`));
+          return;
+        }
         body += chunk.toString();
       });
       req.on('end', () => {


### PR DESCRIPTION
## Summary

Enforces the existing `maxMessageSize` configuration in `readRequestBody()`. The config value was defined in `DEFAULT_HTTP_STREAM_CONFIG` (4MB default) but never checked at runtime, allowing unbounded request body accumulation.

## Changes

- Added size tracking in `readRequestBody()` (`src/transports/http/server.ts`)
- Request is destroyed if body exceeds `maxMessageSize`
- Uses existing config value, no new configuration needed
- Default limit: 4MB (unchanged from `DEFAULT_HTTP_STREAM_CONFIG`)

## Before

```typescript
req.on('data', (chunk) => {
    body += chunk.toString();  // No size check
});
```

## After

```typescript
req.on('data', (chunk) => {
    size += chunk.length;
    if (size > maxSize) {
        req.destroy();
        reject(new Error(`Request body exceeds maximum size of ${maxSize} bytes`));
        return;
    }
    body += chunk.toString();
});
```

Fixes GHSA-353c-v8x9-v7c3