### PR TITLE
fix: add body size limit to readRequestBody (CWE-770)

### DIFF
--- a/src/transports/http/server.ts
+++ b/src/transports/http/server.ts
@@ -136,7 +136,21 @@ export class HttpStreamTransport extends AbstractTransport {
     let transport: StreamableHTTPServerTransport;
 
     // Determine if this is an initialize request (needs body parsing)
-    const body = req.method === 'POST' ? await this.readRequestBody(req) : null;
+    let body: any = null;
+    if (req.method === 'POST') {
+      try {
+        body = await this.readRequestBody(req);
+      } catch (error: any) {
+        if (error.message === 'Request body too large') {
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32600, message: 'Request body too large' }, id: null }));
+          return;
+        }
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null }));
+        return;
+      }
+    }
     const isInitialize = !sessionId && body && isInitializeRequest(body);
 
     // Perform authentication check once at the beginning
@@ -221,10 +235,19 @@ export class HttpStreamTransport extends AbstractTransport {
     });
   }
 
+  private static readonly MAX_BODY_SIZE = 4 * 1024 * 1024; // 4MB
+
   private async readRequestBody(req: IncomingMessage): Promise<any> {
     return new Promise((resolve, reject) => {
       let body = '';
+      let size = 0;
       req.on('data', (chunk) => {
+        size += chunk.length;
+        if (size > HttpServerTransport.MAX_BODY_SIZE) {
+          req.destroy();
+          reject(new Error('Request body too large'));
+          return;
+        }
         body += chunk.toString();
       });
       req.on('end', () => {


### PR DESCRIPTION
## Summary

Fixes GHSA-353c-v8x9-v7c3 — unbounded memory allocation in `readRequestBody` allows denial of service via HTTP transport.

## Problem

`readRequestBody` accumulates request body chunks with `body += chunk.toString()` without any size limit. An attacker can send arbitrarily large HTTP POST bodies, causing unbounded memory growth leading to OOM and denial of service.

No authentication is required. A single HTTP POST is sufficient.

## Fix

- Adds a 4MB body size limit (`MAX_BODY_SIZE`) with a byte counter on each chunk
- Destroys the request stream immediately when the limit is exceeded
- Returns HTTP 413 with a JSON-RPC error response for oversized requests
- Returns HTTP 400 for malformed JSON bodies

## Changes

- `src/transports/http/server.ts`: Added `MAX_BODY_SIZE` constant and size checking in `readRequestBody`, plus proper error handling in `handleMcpRequest`

## References

- [OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html)
- CWE-770: Allocation of Resources Without Limits or Throttling

---

Raza Sharif, CyberSecAI Ltd | contact@agentsign.dev