### PR TITLE
Add AgenticSearch trust badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Framework
 
+[![AgenticSearch](https://agentsearch.cybersecai.co.uk/badge/mcp-framework)](https://agentsearch.cybersecai.co.uk/trust)
+
 MCP-Framework is a framework for building Model Context Protocol (MCP) servers elegantly in TypeScript.
 
 MCP-Framework gives you architecture out of the box, with automatic directory-based discovery for tools, resources, and prompts. Use our powerful MCP abstractions to define tools, resources, or prompts in an elegant way. Our cli makes getting started with your own MCP server a breeze


### PR DESCRIPTION
Adds the AgenticSearch trust badge to the README, as discussed in #173.

Shows the project's trust level in the AgenticSearch index -- the trust-scored search engine for MCP servers.

One line, no code changes.