### PR TITLE
fix: exit cleanly on stdin EOF in StdioServerTransport

### DIFF
--- a/src/transports/stdio/server.ts
+++ b/src/transports/stdio/server.ts
@@ -37,7 +37,22 @@ export class StdioServerTransport implements BaseTransport {
   async start(): Promise<void> {
     await this.transport.start();
     this.running = true;
+
+    // Exit cleanly when the parent process disconnects (stdin EOF). Without
+    // this, the underlying SDK readline poll spins on null reads after the
+    // pipe closes, leaving the server reparented to init at ~99% CPU until
+    // killed manually. Observed daily on macOS Darwin 25.x when the parent
+    // (Claude CLI / Claude Desktop) is hard-killed.
+    process.stdin.on("end", this.handleStdinClose);
+    process.stdin.on("close", this.handleStdinClose);
   }
+
+  private handleStdinClose = (): void => {
+    // Stdio transport has no work to do once stdin is gone. Best-effort
+    // cleanup of the SDK transport, then exit so launchd / parent never sees
+    // a CPU-spinning zombie.
+    this.transport.close().finally(() => process.exit(0));
+  };
 
   async send(message: ExtendedJSONRPCMessage): Promise<void> {
     try {
@@ -73,6 +88,8 @@ export class StdioServerTransport implements BaseTransport {
   }
 
   async close(): Promise<void> {
+    process.stdin.off("end", this.handleStdinClose);
+    process.stdin.off("close", this.handleStdinClose);
     await this.transport.close();
     this.running = false;
   }

--- a/tests/transports/stdio/server.test.ts
+++ b/tests/transports/stdio/server.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, jest, afterEach, beforeEach } from "@jest/globals";
+import { StdioServerTransport } from "../../../src/transports/stdio/server.js";
+
+/**
+ * Regression tests for stdin-EOF handling.
+ *
+ * Without the listeners installed in StdioServerTransport.start(), the
+ * underlying SDK readline poll spins on null reads after the parent process
+ * disconnects, leaving the MCP server reparented to init at ~99% CPU.
+ *
+ * These tests verify:
+ *  1. process.stdin "close" → process.exit(0)
+ *  2. process.stdin "end"   → process.exit(0)
+ *  3. close() removes the listeners (no leak / re-instantiation safety)
+ */
+describe("StdioServerTransport — stdin EOF handling", () => {
+  let transport: StdioServerTransport | undefined;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    // Mock process.exit so the test runner survives — record the call instead.
+    exitSpy = jest.spyOn(process, "exit").mockImplementation((() => {
+      // Intentionally a no-op. Real behavior is verified via the spy assertion.
+    }) as never);
+  });
+
+  afterEach(async () => {
+    if (transport?.isRunning()) {
+      await transport.close();
+    }
+    transport = undefined;
+    exitSpy.mockRestore();
+  });
+
+  it('exits with code 0 when process.stdin emits "close"', async () => {
+    transport = new StdioServerTransport();
+    await transport.start();
+
+    process.stdin.emit("close");
+    // Wait one microtask + macrotask for transport.close().finally chain.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('exits with code 0 when process.stdin emits "end"', async () => {
+    transport = new StdioServerTransport();
+    await transport.start();
+
+    process.stdin.emit("end");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("removes stdin listeners on close() so re-instantiation is leak-free", async () => {
+    const baselineEnd = process.stdin.listenerCount("end");
+    const baselineClose = process.stdin.listenerCount("close");
+
+    transport = new StdioServerTransport();
+    await transport.start();
+
+    expect(process.stdin.listenerCount("end")).toBe(baselineEnd + 1);
+    expect(process.stdin.listenerCount("close")).toBe(baselineClose + 1);
+
+    await transport.close();
+    transport = undefined;
+
+    expect(process.stdin.listenerCount("end")).toBe(baselineEnd);
+    expect(process.stdin.listenerCount("close")).toBe(baselineClose);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #181.

`StdioServerTransport.start()` now installs `end`/`close` listeners on `process.stdin` so the server exits cleanly when its parent disconnects, instead of busy-looping at ~99% CPU as a `PPID=1` zombie until killed manually.

The bug is observed daily on macOS Darwin 25.x whenever the parent (Claude CLI / Claude Desktop) is hard-killed. Source-code analysis is in the linked issue. Quick recap: `StdioServerTransport` delegates everything to `@modelcontextprotocol/sdk`'s `StdioServerTransport`, which uses readline under the hood — when the parent dies on Darwin, the EOF doesn't propagate to a clean stream-end event, the readline poll spins on null reads, and nothing in either layer calls `process.exit()`. This PR adds the missing exit guard at the consumer layer where the lifecycle is owned.

## Changes

- `src/transports/stdio/server.ts` (+17 LOC) — install `end`/`close` listeners on `process.stdin` in `start()`, remove them in `close()` (symmetric, leak-free), call `process.exit(0)` after best-effort `transport.close()` when either fires.
- `tests/transports/stdio/server.test.ts` (+65 LOC, new file) — 3 tests:
  1. `close` event → `process.exit(0)` called.
  2. `end` event → `process.exit(0)` called.
  3. listeners removed on `close()` (re-instantiation leak-free).

## Why this layer (not the SDK)

The SDK can't safely call `process.exit()` because some consumers might want to intercept stdin EOF and do graceful shutdown. But a stdio MCP server has no other input source — once stdin is gone, it has nothing to do. The right place for the exit guard is in `mcp-framework`'s wrapper, where the process lifecycle is owned. (Cross-filing at `modelcontextprotocol/typescript-sdk` is also possible but seems unnecessary if `mcp-framework` handles it.)

## Test plan

```sh
npm install
npm test -- tests/transports/stdio/server.test.ts   # 3/3 pass
npm test                                              # 852 pass / 1 baseline flake; 60/66 suites pass (6 pre-existing failures unrelated to transports)
npm run build                                         # tsc clean
```

Real-world repro verified: with the patch installed, killing the parent process of a default `mcp create test-server` no longer leaves a `PPID=1` zombie. Without the patch, the same operation leaves a process spinning at 99% CPU indefinitely.

## Open questions / alternatives

Happy to redo in a different shape if you'd prefer:

- **Opt-out option** — expose `exitOnStdinClose: boolean` (default `true`) on the constructor for consumers who want different shutdown semantics. Adds one constructor arg and one boolean check; minor surface increase.
- **Route through `onclose` chain** — instead of `process.exit(0)`, fire the existing `onclose` handler if set, then exit. Slightly more invasive; lets consumers run cleanup before exit.
- **Move to `MCPServer.start()`** — install the guard at the higher level so non-stdio transports don't pay for it (they don't anyway, since they don't read stdin, but it's slightly more explicit).

Default chosen: minimal patch at the transport layer, hard `process.exit(0)` after best-effort SDK cleanup. Happy to iterate.

## Workaround we're using until this lands

We ship a launchd watchdog (~50 LOC reaper script) on dev machines that detects the orphan signature (`PPID=1` + MCP allowlist match + `%CPU > 50` + `etime < 10 min`) and `SIGKILL`s on a 120s probe. Effective at zero false positives but obviously a band-aid. Shipping this PR upstream lets us delete that mitigation.

Thanks for maintaining `mcp-framework`!
