### PR TITLE
Add package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Framework for building Model Context Protocol (MCP) servers in Typescript",
   "type": "module",
   "author": "Alex Andru <alex@andru.codes>",
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -61,5 +61,14 @@
   "engines": {
     "node": ">=18.19.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QuantGeekDev/mcp-framework.git",
+    "directory": "packages/docs"
+  },
+  "homepage": "https://github.com/QuantGeekDev/mcp-framework/tree/main/packages/docs#readme",
+  "bugs": {
+    "url": "https://github.com/QuantGeekDev/mcp-framework/issues"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add MIT license metadata to the published `mcp-framework` package manifest
- add repository, homepage, and bugs metadata to the published `@mcpframework/docs` package manifest
- align metadata with the repository's existing MIT LICENSE file and public issue tracker

## Verification
- `npm view mcp-framework@latest license --json`
- `npm view @mcpframework/docs@latest name version license repository homepage bugs --json`
- Node manifest assertion for `package.json`
- Node manifest assertion for `packages/docs/package.json`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from the root package
- `npm pack --dry-run --ignore-scripts --json` from `packages/docs`

## Scope
Manifest metadata only. No runtime code, dependencies, exports, generated output, or lockfile changes.